### PR TITLE
Scrape news and send to telegram

### DIFF
--- a/chinapress_news_bot.py
+++ b/chinapress_news_bot.py
@@ -1,0 +1,37 @@
+import asyncio
+from datetime import datetime
+from dotenv import load_dotenv
+
+from modules.news_crawler import fetch_chinapress_news, select_random_news
+from modules.telegram_bot import send_telegram_message, send_news_to_telegram
+
+
+def main():
+    load_dotenv()
+
+    news = fetch_chinapress_news(max_items=50)
+    if not news:
+        asyncio.run(send_telegram_message("❌ 抓取失败，未获取到中国报新闻"))
+        return
+
+    # 抓取报告
+    debug = f"🔍 中国报抓取到 {len(news)} 条新闻：\n"
+    for i, n in enumerate(news[:10], 1):
+        debug += f"{i}. {n['title']}\n{n['link']}\n\n"
+    asyncio.run(send_telegram_message(debug))
+
+    # 推送 10 条
+    selected = select_random_news(news, 10)
+    sent = asyncio.run(send_news_to_telegram(selected))
+
+    summary = (
+        f"📰 中国报推送报告\n"
+        f"• 抓取: {len(news)} 条\n"
+        f"• 推送: {sent} 条\n"
+        f"• 时间: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+    )
+    asyncio.run(send_telegram_message(summary))
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/news_crawler.py
+++ b/modules/news_crawler.py
@@ -8,13 +8,18 @@ logger = logging.getLogger('news_crawler')
 # Google 新闻（中文）RSS，包含马来西亚新闻
 RSS_FEED = "https://news.google.com/rss/search?q=马来西亚&hl=zh-CN&gl=MY&ceid=MY:zh-Hans"
 MIN_COUNT = 10
+CHINAPRESS_FEED = "https://www.chinapress.com.my/feed/"
 
 HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/115.0.0.0 Safari/537.36"
-    )
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "Connection": "keep-alive",
+    "DNT": "1",
 }
 
 def fetch_news() -> list[dict]:
@@ -71,3 +76,120 @@ def fetch_news() -> list[dict]:
 def select_random_news(news_list: list[dict], count: int = 10) -> list[dict]:
     import random
     return random.sample(news_list, min(len(news_list), count))
+
+
+def fetch_chinapress_news(max_items: int = 30) -> list[dict]:
+    """
+    抓取中国报（Chinapress）RSS，尽量提取标题、链接、图片、简介。
+    """
+    def parse_from_feed() -> list[dict]:
+        try:
+            resp = requests.get(CHINAPRESS_FEED, headers=HEADERS, timeout=12)
+            resp.raise_for_status()
+            root = ET.fromstring(resp.content)
+        except Exception as e:
+            logger.error(f"RSS 请求失败 ({CHINAPRESS_FEED}): {e}", exc_info=True)
+            return []
+
+        results: list[dict] = []
+        seen = set()
+        ns = {
+            'content': 'http://purl.org/rss/1.0/modules/content/',
+            'media': 'http://search.yahoo.com/mrss/'
+        }
+
+        for item in root.findall('.//item'):
+            raw_title = item.findtext('title', '').strip()
+            link = item.findtext('link', '').strip()
+            if not raw_title or not link or link in seen:
+                continue
+
+            raw_desc = item.findtext('description', '') or ''
+            content_encoded = None
+            content_node = item.find('content:encoded', ns)
+            if content_node is not None and content_node.text:
+                content_encoded = content_node.text
+
+            html_block = content_encoded or raw_desc
+            soup = BeautifulSoup(html_block, 'html.parser')
+            text_content = soup.get_text(separator=' ', strip=True)
+            text_content = ''.join(c for c in text_content if c.isalnum() or c.isspace())
+
+            image_url = None
+            img = soup.find('img')
+            if img and img.has_attr('src'):
+                image_url = img['src']
+            if not image_url:
+                m_cont = item.find('media:content', ns)
+                if m_cont is not None and m_cont.attrib.get('url'):
+                    image_url = m_cont.attrib['url']
+                else:
+                    m_thumb = item.find('media:thumbnail', ns)
+                    if m_thumb is not None and m_thumb.attrib.get('url'):
+                        image_url = m_thumb.attrib['url']
+
+            title = ''.join(c for c in raw_title if c.isalnum() or c.isspace())
+
+            results.append({
+                'title': title,
+                'link': link,
+                'image': image_url,
+                'content': text_content
+            })
+
+            seen.add(link)
+            if len(results) >= max(MIN_COUNT, max_items):
+                break
+
+        return results
+
+    def parse_from_homepage() -> list[dict]:
+        url = "https://www.chinapress.com.my/"
+        try:
+            resp = requests.get(url, headers=HEADERS, timeout=12)
+            resp.raise_for_status()
+        except Exception as e:
+            logger.error(f"首页请求失败 ({url}): {e}", exc_info=True)
+            return []
+
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        results: list[dict] = []
+        seen = set()
+
+        # 宽松遍历所有 <a>，过滤域名与标题长度
+        for a in soup.select('a'):
+            href = (a.get('href') or '').strip()
+            title = a.get_text(strip=True)
+            if not href or not title:
+                continue
+            # 统一转绝对链接
+            if href.startswith('/'):
+                href = 'https://www.chinapress.com.my' + href
+            if not href.startswith('http'):
+                continue
+            if 'chinapress.com.my' not in href:
+                continue
+            if len(title) < 6:
+                continue
+            if href in seen:
+                continue
+            seen.add(href)
+            results.append({
+                'title': ''.join(c for c in title if c.isalnum() or c.isspace()),
+                'link': href,
+                'image': None,
+                'content': ''
+            })
+            if len(results) >= max_items:
+                break
+
+        return results
+
+    # 先尝试 RSS，再回退首页 HTML 解析
+    rss_results = parse_from_feed()
+    if rss_results:
+        logger.info(f"✅ 中国报抓到 {len(rss_results)} 条（RSS）")
+        return rss_results
+    html_results = parse_from_homepage()
+    logger.info(f"✅ 中国报抓到 {len(html_results)} 条（HTML）")
+    return html_results

--- a/run_chinapress.py
+++ b/run_chinapress.py
@@ -1,0 +1,53 @@
+import argparse
+import asyncio
+from datetime import datetime
+from dotenv import load_dotenv
+
+from modules.news_crawler import fetch_chinapress_news, select_random_news
+from modules.telegram_bot import send_telegram_message, send_news_to_telegram
+
+
+async def run(dry_run: bool, count: int):
+    start = datetime.now()
+    news = fetch_chinapress_news(max_items=max(count, 10))
+    if not news:
+        await send_telegram_message("❌ 抓取失败，未获取到中国报新闻")
+        return
+
+    debug = f"🔍 中国报抓取到 {len(news)} 条新闻：\n"
+    for i, n in enumerate(news[:count], 1):
+        debug += f"{i}. {n['title']}\n{n['link']}\n\n"
+
+    # 发送抓取报告
+    await send_telegram_message(debug)
+
+    selected = select_random_news(news, count)
+    if dry_run:
+        # 仅打印，不推送
+        for i, n in enumerate(selected, 1):
+            print(f"{i}. {n['title']}\n{n['link']}\n")
+        return
+
+    sent = await send_news_to_telegram(selected)
+    dur = (datetime.now() - start).total_seconds()
+    summary = (
+        f"📰 中国报推送报告\n"
+        f"• 抓取: {len(news)} 条\n"
+        f"• 推送: {sent} 条\n"
+        f"• 耗时: {dur:.1f} 秒"
+    )
+    await send_telegram_message(summary)
+
+
+def main():
+    load_dotenv()
+    parser = argparse.ArgumentParser(description="抓取中国报并发送到 Telegram")
+    parser.add_argument("--count", type=int, default=10, help="推送条数（默认10）")
+    parser.add_argument("--dry-run", action="store_true", help="仅打印，不发送")
+    args = parser.parse_args()
+
+    asyncio.run(run(args.dry_run, args.count))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add Chinapress news scraping with RSS and HTML fallback for Telegram delivery.

The Chinapress RSS feed had redirection issues, so a fallback to HTML scraping of the homepage was implemented to ensure reliable news fetching, including robust link and title filtering.

---
<a href="https://cursor.com/background-agent?bcId=bc-8966d7c2-1361-4b57-ac4f-1189f39441d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8966d7c2-1361-4b57-ac4f-1189f39441d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

